### PR TITLE
adds space to end of string

### DIFF
--- a/app/pages/4_‎ ‎ ‎ ‎ ● Trendspotting.py
+++ b/app/pages/4_‎ ‎ ‎ ‎ ● Trendspotting.py
@@ -110,7 +110,7 @@ cols_page = st.columns([14,72,14])
 with cols_page[1]:
     # Google Trends retrieval tool ###########
     st.write(
-        "Using the form below, select a date" 
+        "Using the form below, select a date " 
         "to retrieve the top 1 search term(s) in the US."
     )
     with st.form('form_google_trends'):


### PR DESCRIPTION
Corrects lack of space in "Using the form below, select a dateto retrieve the top 1 search term(s) in the US." to "Using the form below, select a date to retrieve the top 1 search term(s) in the US."