### PR TITLE
Avoid tracking the hidden files generated during deploying firebase and angular

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -169,3 +169,7 @@ override.tf.json
 .terraformrc
 terraform.rc
 infra/output_config/*
+
+# Post deployment files
+frontend/.firebase 
+frontend/.angular


### PR DESCRIPTION
1. The deployment generates these files that can be close to 40+ in number..
1. Add to gitignore the following:
     - `frontend/.firebase`
     - `frontend/.angular`



PR tested